### PR TITLE
Update NFS export size check

### DIFF
--- a/templates/checker.sh.j2
+++ b/templates/checker.sh.j2
@@ -155,7 +155,7 @@ for i in dhcpd named haproxy httpd tftp keepalived local-registry; do echo -e "S
 }
 ###
 nfs-info () {
-availablesize=$(df -h --output=avail /export | tail -1 | tr -d " ""\t""[:alpha:]")
+availablesize=$(df -BM --output=avail /export | tail -1 | tr -d " ""\t""[:alpha:]")
 warningsize=50
 #
 cat <<EOF


### PR DESCRIPTION
df -h may output size like 1.1T which cause an error.
df -BM will output Megabytes and solve the issue